### PR TITLE
Add dummy po files for supported languages.

### DIFF
--- a/po/da.po
+++ b/po/da.po
@@ -1,11 +1,11 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR SUSE LLC
-# This file is distributed under the same license as the PACKAGE package.
+# This file is distributed under the same license as the barrel package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: barrel VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-01-11 16:33+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"

--- a/po/es.po
+++ b/po/es.po
@@ -1,119 +1,117 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR SUSE LLC
+# Spanish translations for barrel package.
+# Copyright (C) 2022 SUSE LLC
 # This file is distributed under the same license as the barrel package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Automatically generated, 2022.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: barrel VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-01-11 16:33+0100\n"
-"PO-Revision-Date: 2022-01-18 18:12+0000\n"
-"Last-Translator: David Medina <medipas@gmail.com>\n"
-"Language-Team: Catalan <https://l10n.opensuse.org/projects/barrel/master/ca/>"
-"\n"
-"Language: ca\n"
+"PO-Revision-Date: 2022-01-11 16:33+0100\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=ASCII\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.9.1\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "Activating..."
-msgstr "Activant..."
+msgstr ""
 
 msgid "Adds devices to a pool."
-msgstr "Afegeix dispositius a una agrupació."
+msgstr ""
 
 msgid "Alias for 'create encryption --type luks1'"
-msgstr "Àlies per a \"create encryption --type luks1\""
+msgstr ""
 
 msgid "Alias for 'create encryption --type luks2'"
-msgstr "Àlies per a \"create encryption --type luks2\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type btrfs'"
-msgstr "Àlies per a \"create filesystem --type btrfs\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ext2'"
-msgstr "Àlies per a \"create filesystem --type ext2\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ext3'"
-msgstr "Àlies per a \"create filesystem --type ext3\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ext4'"
-msgstr "Àlies per a \"create filesystem --type ext4\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type f2fs'"
-msgstr "Àlies per a \"create filesystem --type f2fs\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ntfs'"
-msgstr "Àlies per a \"create filesystem --type ntfs\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type swap'"
-msgstr "Àlies per a \"create filesystem --type swap\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type xfs'"
-msgstr "Àlies per a \"create filesystem --type xfs\""
+msgstr ""
 
 msgid "Alias for 'create partition-table --type gpt'"
-msgstr "Àlies per a \"create partition-table --type gpt\""
+msgstr ""
 
 msgid "Alias for 'create partition-table --type ms-dos'"
-msgstr "Àlies per a \"create partition-table --type ms-dos\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 0'"
-msgstr "Àlies per a \"create raid --level 0\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 1'"
-msgstr "Àlies per a \"create raid --level 1\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 10'"
-msgstr "Àlies per a \"create raid --level 10\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 4'"
-msgstr "Àlies per a \"create raid --level 4\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 5'"
-msgstr "Àlies per a \"create raid --level 5\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 6'"
-msgstr "Àlies per a \"create raid --level 6\""
+msgstr ""
 
 msgid "Block Size"
-msgstr "Mida de bloc"
+msgstr ""
 
 msgid "Bus ID"
-msgstr "ID de BUS"
+msgstr ""
 
 msgid "Chunk Size"
-msgstr "Mida del tros"
+msgstr ""
 
 msgid "Clears the stack."
-msgstr "Neteja la pila."
+msgstr ""
 
 msgid "Commands:"
-msgstr "Ordres:"
+msgstr ""
 
 msgid "Commit changes?"
-msgstr "Voleu aplicar els canvis?"
+msgstr ""
 
 msgid "Commits changes to disk and quits barrel."
-msgstr "Aplica els canvis al disc i surt del barril."
+msgstr ""
 
 msgid "Continue?"
-msgstr "Voleu continuar?"
+msgstr ""
 
 msgid "Creates a new LVM logical volume."
-msgstr "Crea un volum lògic LVM nou."
+msgstr ""
 
 msgid "Creates a new LVM volume group."
-msgstr "Crea un grup de volums LVM nou."
+msgstr ""
 
 msgid "Creates a new RAID."
-msgstr "Crea una RAID nova."
+msgstr ""
 
 msgid "Creates a new encryption device."
-msgstr "Crea un dispositiu d'encriptació nou."
+msgstr ""
 
 msgid "Creates a new file system."
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,119 +1,117 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR SUSE LLC
+# French translations for barrel package.
+# Copyright (C) 2022 SUSE LLC
 # This file is distributed under the same license as the barrel package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Automatically generated, 2022.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: barrel VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-01-11 16:33+0100\n"
-"PO-Revision-Date: 2022-01-18 18:12+0000\n"
-"Last-Translator: David Medina <medipas@gmail.com>\n"
-"Language-Team: Catalan <https://l10n.opensuse.org/projects/barrel/master/ca/>"
-"\n"
-"Language: ca\n"
+"PO-Revision-Date: 2022-01-11 16:33+0100\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=ASCII\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.9.1\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 msgid "Activating..."
-msgstr "Activant..."
+msgstr ""
 
 msgid "Adds devices to a pool."
-msgstr "Afegeix dispositius a una agrupació."
+msgstr ""
 
 msgid "Alias for 'create encryption --type luks1'"
-msgstr "Àlies per a \"create encryption --type luks1\""
+msgstr ""
 
 msgid "Alias for 'create encryption --type luks2'"
-msgstr "Àlies per a \"create encryption --type luks2\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type btrfs'"
-msgstr "Àlies per a \"create filesystem --type btrfs\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ext2'"
-msgstr "Àlies per a \"create filesystem --type ext2\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ext3'"
-msgstr "Àlies per a \"create filesystem --type ext3\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ext4'"
-msgstr "Àlies per a \"create filesystem --type ext4\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type f2fs'"
-msgstr "Àlies per a \"create filesystem --type f2fs\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ntfs'"
-msgstr "Àlies per a \"create filesystem --type ntfs\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type swap'"
-msgstr "Àlies per a \"create filesystem --type swap\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type xfs'"
-msgstr "Àlies per a \"create filesystem --type xfs\""
+msgstr ""
 
 msgid "Alias for 'create partition-table --type gpt'"
-msgstr "Àlies per a \"create partition-table --type gpt\""
+msgstr ""
 
 msgid "Alias for 'create partition-table --type ms-dos'"
-msgstr "Àlies per a \"create partition-table --type ms-dos\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 0'"
-msgstr "Àlies per a \"create raid --level 0\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 1'"
-msgstr "Àlies per a \"create raid --level 1\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 10'"
-msgstr "Àlies per a \"create raid --level 10\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 4'"
-msgstr "Àlies per a \"create raid --level 4\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 5'"
-msgstr "Àlies per a \"create raid --level 5\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 6'"
-msgstr "Àlies per a \"create raid --level 6\""
+msgstr ""
 
 msgid "Block Size"
-msgstr "Mida de bloc"
+msgstr ""
 
 msgid "Bus ID"
-msgstr "ID de BUS"
+msgstr ""
 
 msgid "Chunk Size"
-msgstr "Mida del tros"
+msgstr ""
 
 msgid "Clears the stack."
-msgstr "Neteja la pila."
+msgstr ""
 
 msgid "Commands:"
-msgstr "Ordres:"
+msgstr ""
 
 msgid "Commit changes?"
-msgstr "Voleu aplicar els canvis?"
+msgstr ""
 
 msgid "Commits changes to disk and quits barrel."
-msgstr "Aplica els canvis al disc i surt del barril."
+msgstr ""
 
 msgid "Continue?"
-msgstr "Voleu continuar?"
+msgstr ""
 
 msgid "Creates a new LVM logical volume."
-msgstr "Crea un volum lògic LVM nou."
+msgstr ""
 
 msgid "Creates a new LVM volume group."
-msgstr "Crea un grup de volums LVM nou."
+msgstr ""
 
 msgid "Creates a new RAID."
-msgstr "Crea una RAID nova."
+msgstr ""
 
 msgid "Creates a new encryption device."
-msgstr "Crea un dispositiu d'encriptació nou."
+msgstr ""
 
 msgid "Creates a new file system."
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -1,119 +1,117 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR SUSE LLC
+# Italian translations for barrel package.
+# Copyright (C) 2022 SUSE LLC
 # This file is distributed under the same license as the barrel package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Automatically generated, 2022.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: barrel VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-01-11 16:33+0100\n"
-"PO-Revision-Date: 2022-01-18 18:12+0000\n"
-"Last-Translator: David Medina <medipas@gmail.com>\n"
-"Language-Team: Catalan <https://l10n.opensuse.org/projects/barrel/master/ca/>"
-"\n"
-"Language: ca\n"
+"PO-Revision-Date: 2022-01-11 16:33+0100\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: it\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=ASCII\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.9.1\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "Activating..."
-msgstr "Activant..."
+msgstr ""
 
 msgid "Adds devices to a pool."
-msgstr "Afegeix dispositius a una agrupació."
+msgstr ""
 
 msgid "Alias for 'create encryption --type luks1'"
-msgstr "Àlies per a \"create encryption --type luks1\""
+msgstr ""
 
 msgid "Alias for 'create encryption --type luks2'"
-msgstr "Àlies per a \"create encryption --type luks2\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type btrfs'"
-msgstr "Àlies per a \"create filesystem --type btrfs\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ext2'"
-msgstr "Àlies per a \"create filesystem --type ext2\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ext3'"
-msgstr "Àlies per a \"create filesystem --type ext3\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ext4'"
-msgstr "Àlies per a \"create filesystem --type ext4\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type f2fs'"
-msgstr "Àlies per a \"create filesystem --type f2fs\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ntfs'"
-msgstr "Àlies per a \"create filesystem --type ntfs\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type swap'"
-msgstr "Àlies per a \"create filesystem --type swap\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type xfs'"
-msgstr "Àlies per a \"create filesystem --type xfs\""
+msgstr ""
 
 msgid "Alias for 'create partition-table --type gpt'"
-msgstr "Àlies per a \"create partition-table --type gpt\""
+msgstr ""
 
 msgid "Alias for 'create partition-table --type ms-dos'"
-msgstr "Àlies per a \"create partition-table --type ms-dos\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 0'"
-msgstr "Àlies per a \"create raid --level 0\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 1'"
-msgstr "Àlies per a \"create raid --level 1\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 10'"
-msgstr "Àlies per a \"create raid --level 10\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 4'"
-msgstr "Àlies per a \"create raid --level 4\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 5'"
-msgstr "Àlies per a \"create raid --level 5\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 6'"
-msgstr "Àlies per a \"create raid --level 6\""
+msgstr ""
 
 msgid "Block Size"
-msgstr "Mida de bloc"
+msgstr ""
 
 msgid "Bus ID"
-msgstr "ID de BUS"
+msgstr ""
 
 msgid "Chunk Size"
-msgstr "Mida del tros"
+msgstr ""
 
 msgid "Clears the stack."
-msgstr "Neteja la pila."
+msgstr ""
 
 msgid "Commands:"
-msgstr "Ordres:"
+msgstr ""
 
 msgid "Commit changes?"
-msgstr "Voleu aplicar els canvis?"
+msgstr ""
 
 msgid "Commits changes to disk and quits barrel."
-msgstr "Aplica els canvis al disc i surt del barril."
+msgstr ""
 
 msgid "Continue?"
-msgstr "Voleu continuar?"
+msgstr ""
 
 msgid "Creates a new LVM logical volume."
-msgstr "Crea un volum lògic LVM nou."
+msgstr ""
 
 msgid "Creates a new LVM volume group."
-msgstr "Crea un grup de volums LVM nou."
+msgstr ""
 
 msgid "Creates a new RAID."
-msgstr "Crea una RAID nova."
+msgstr ""
 
 msgid "Creates a new encryption device."
-msgstr "Crea un dispositiu d'encriptació nou."
+msgstr ""
 
 msgid "Creates a new file system."
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,119 +1,117 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR SUSE LLC
+# Japanese translations for barrel package.
+# Copyright (C) 2022 SUSE LLC
 # This file is distributed under the same license as the barrel package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Automatically generated, 2022.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: barrel VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-01-11 16:33+0100\n"
-"PO-Revision-Date: 2022-01-18 18:12+0000\n"
-"Last-Translator: David Medina <medipas@gmail.com>\n"
-"Language-Team: Catalan <https://l10n.opensuse.org/projects/barrel/master/ca/>"
-"\n"
-"Language: ca\n"
+"PO-Revision-Date: 2022-01-11 16:33+0100\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ja\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=ASCII\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.9.1\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 msgid "Activating..."
-msgstr "Activant..."
+msgstr ""
 
 msgid "Adds devices to a pool."
-msgstr "Afegeix dispositius a una agrupació."
+msgstr ""
 
 msgid "Alias for 'create encryption --type luks1'"
-msgstr "Àlies per a \"create encryption --type luks1\""
+msgstr ""
 
 msgid "Alias for 'create encryption --type luks2'"
-msgstr "Àlies per a \"create encryption --type luks2\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type btrfs'"
-msgstr "Àlies per a \"create filesystem --type btrfs\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ext2'"
-msgstr "Àlies per a \"create filesystem --type ext2\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ext3'"
-msgstr "Àlies per a \"create filesystem --type ext3\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ext4'"
-msgstr "Àlies per a \"create filesystem --type ext4\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type f2fs'"
-msgstr "Àlies per a \"create filesystem --type f2fs\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ntfs'"
-msgstr "Àlies per a \"create filesystem --type ntfs\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type swap'"
-msgstr "Àlies per a \"create filesystem --type swap\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type xfs'"
-msgstr "Àlies per a \"create filesystem --type xfs\""
+msgstr ""
 
 msgid "Alias for 'create partition-table --type gpt'"
-msgstr "Àlies per a \"create partition-table --type gpt\""
+msgstr ""
 
 msgid "Alias for 'create partition-table --type ms-dos'"
-msgstr "Àlies per a \"create partition-table --type ms-dos\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 0'"
-msgstr "Àlies per a \"create raid --level 0\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 1'"
-msgstr "Àlies per a \"create raid --level 1\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 10'"
-msgstr "Àlies per a \"create raid --level 10\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 4'"
-msgstr "Àlies per a \"create raid --level 4\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 5'"
-msgstr "Àlies per a \"create raid --level 5\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 6'"
-msgstr "Àlies per a \"create raid --level 6\""
+msgstr ""
 
 msgid "Block Size"
-msgstr "Mida de bloc"
+msgstr ""
 
 msgid "Bus ID"
-msgstr "ID de BUS"
+msgstr ""
 
 msgid "Chunk Size"
-msgstr "Mida del tros"
+msgstr ""
 
 msgid "Clears the stack."
-msgstr "Neteja la pila."
+msgstr ""
 
 msgid "Commands:"
-msgstr "Ordres:"
+msgstr ""
 
 msgid "Commit changes?"
-msgstr "Voleu aplicar els canvis?"
+msgstr ""
 
 msgid "Commits changes to disk and quits barrel."
-msgstr "Aplica els canvis al disc i surt del barril."
+msgstr ""
 
 msgid "Continue?"
-msgstr "Voleu continuar?"
+msgstr ""
 
 msgid "Creates a new LVM logical volume."
-msgstr "Crea un volum lògic LVM nou."
+msgstr ""
 
 msgid "Creates a new LVM volume group."
-msgstr "Crea un grup de volums LVM nou."
+msgstr ""
 
 msgid "Creates a new RAID."
-msgstr "Crea una RAID nova."
+msgstr ""
 
 msgid "Creates a new encryption device."
-msgstr "Crea un dispositiu d'encriptació nou."
+msgstr ""
 
 msgid "Creates a new file system."
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,119 +1,118 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR SUSE LLC
+# Portuguese translations for barrel package
+# Traduções em português brasileiro para o pacote barrel.
+# Copyright (C) 2022 SUSE LLC
 # This file is distributed under the same license as the barrel package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Automatically generated, 2022.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: barrel VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-01-11 16:33+0100\n"
-"PO-Revision-Date: 2022-01-18 18:12+0000\n"
-"Last-Translator: David Medina <medipas@gmail.com>\n"
-"Language-Team: Catalan <https://l10n.opensuse.org/projects/barrel/master/ca/>"
-"\n"
-"Language: ca\n"
+"PO-Revision-Date: 2022-01-11 16:33+0100\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.9.1\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 msgid "Activating..."
-msgstr "Activant..."
+msgstr ""
 
 msgid "Adds devices to a pool."
-msgstr "Afegeix dispositius a una agrupació."
+msgstr ""
 
 msgid "Alias for 'create encryption --type luks1'"
-msgstr "Àlies per a \"create encryption --type luks1\""
+msgstr ""
 
 msgid "Alias for 'create encryption --type luks2'"
-msgstr "Àlies per a \"create encryption --type luks2\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type btrfs'"
-msgstr "Àlies per a \"create filesystem --type btrfs\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ext2'"
-msgstr "Àlies per a \"create filesystem --type ext2\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ext3'"
-msgstr "Àlies per a \"create filesystem --type ext3\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ext4'"
-msgstr "Àlies per a \"create filesystem --type ext4\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type f2fs'"
-msgstr "Àlies per a \"create filesystem --type f2fs\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ntfs'"
-msgstr "Àlies per a \"create filesystem --type ntfs\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type swap'"
-msgstr "Àlies per a \"create filesystem --type swap\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type xfs'"
-msgstr "Àlies per a \"create filesystem --type xfs\""
+msgstr ""
 
 msgid "Alias for 'create partition-table --type gpt'"
-msgstr "Àlies per a \"create partition-table --type gpt\""
+msgstr ""
 
 msgid "Alias for 'create partition-table --type ms-dos'"
-msgstr "Àlies per a \"create partition-table --type ms-dos\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 0'"
-msgstr "Àlies per a \"create raid --level 0\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 1'"
-msgstr "Àlies per a \"create raid --level 1\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 10'"
-msgstr "Àlies per a \"create raid --level 10\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 4'"
-msgstr "Àlies per a \"create raid --level 4\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 5'"
-msgstr "Àlies per a \"create raid --level 5\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 6'"
-msgstr "Àlies per a \"create raid --level 6\""
+msgstr ""
 
 msgid "Block Size"
-msgstr "Mida de bloc"
+msgstr ""
 
 msgid "Bus ID"
-msgstr "ID de BUS"
+msgstr ""
 
 msgid "Chunk Size"
-msgstr "Mida del tros"
+msgstr ""
 
 msgid "Clears the stack."
-msgstr "Neteja la pila."
+msgstr ""
 
 msgid "Commands:"
-msgstr "Ordres:"
+msgstr ""
 
 msgid "Commit changes?"
-msgstr "Voleu aplicar els canvis?"
+msgstr ""
 
 msgid "Commits changes to disk and quits barrel."
-msgstr "Aplica els canvis al disc i surt del barril."
+msgstr ""
 
 msgid "Continue?"
-msgstr "Voleu continuar?"
+msgstr ""
 
 msgid "Creates a new LVM logical volume."
-msgstr "Crea un volum lògic LVM nou."
+msgstr ""
 
 msgid "Creates a new LVM volume group."
-msgstr "Crea un grup de volums LVM nou."
+msgstr ""
 
 msgid "Creates a new RAID."
-msgstr "Crea una RAID nova."
+msgstr ""
 
 msgid "Creates a new encryption device."
-msgstr "Crea un dispositiu d'encriptació nou."
+msgstr ""
 
 msgid "Creates a new file system."
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,119 +1,117 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR SUSE LLC
+# Chinese translations for barrel package
+# barrel 软件包的简体中文翻译.
+# Copyright (C) 2022 SUSE LLC
 # This file is distributed under the same license as the barrel package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Automatically generated, 2022.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: barrel VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-01-11 16:33+0100\n"
-"PO-Revision-Date: 2022-01-18 18:12+0000\n"
-"Last-Translator: David Medina <medipas@gmail.com>\n"
-"Language-Team: Catalan <https://l10n.opensuse.org/projects/barrel/master/ca/>"
-"\n"
-"Language: ca\n"
+"PO-Revision-Date: 2022-01-11 16:33+0100\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.9.1\n"
 
 msgid "Activating..."
-msgstr "Activant..."
+msgstr ""
 
 msgid "Adds devices to a pool."
-msgstr "Afegeix dispositius a una agrupació."
+msgstr ""
 
 msgid "Alias for 'create encryption --type luks1'"
-msgstr "Àlies per a \"create encryption --type luks1\""
+msgstr ""
 
 msgid "Alias for 'create encryption --type luks2'"
-msgstr "Àlies per a \"create encryption --type luks2\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type btrfs'"
-msgstr "Àlies per a \"create filesystem --type btrfs\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ext2'"
-msgstr "Àlies per a \"create filesystem --type ext2\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ext3'"
-msgstr "Àlies per a \"create filesystem --type ext3\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ext4'"
-msgstr "Àlies per a \"create filesystem --type ext4\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type f2fs'"
-msgstr "Àlies per a \"create filesystem --type f2fs\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ntfs'"
-msgstr "Àlies per a \"create filesystem --type ntfs\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type swap'"
-msgstr "Àlies per a \"create filesystem --type swap\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type xfs'"
-msgstr "Àlies per a \"create filesystem --type xfs\""
+msgstr ""
 
 msgid "Alias for 'create partition-table --type gpt'"
-msgstr "Àlies per a \"create partition-table --type gpt\""
+msgstr ""
 
 msgid "Alias for 'create partition-table --type ms-dos'"
-msgstr "Àlies per a \"create partition-table --type ms-dos\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 0'"
-msgstr "Àlies per a \"create raid --level 0\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 1'"
-msgstr "Àlies per a \"create raid --level 1\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 10'"
-msgstr "Àlies per a \"create raid --level 10\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 4'"
-msgstr "Àlies per a \"create raid --level 4\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 5'"
-msgstr "Àlies per a \"create raid --level 5\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 6'"
-msgstr "Àlies per a \"create raid --level 6\""
+msgstr ""
 
 msgid "Block Size"
-msgstr "Mida de bloc"
+msgstr ""
 
 msgid "Bus ID"
-msgstr "ID de BUS"
+msgstr ""
 
 msgid "Chunk Size"
-msgstr "Mida del tros"
+msgstr ""
 
 msgid "Clears the stack."
-msgstr "Neteja la pila."
+msgstr ""
 
 msgid "Commands:"
-msgstr "Ordres:"
+msgstr ""
 
 msgid "Commit changes?"
-msgstr "Voleu aplicar els canvis?"
+msgstr ""
 
 msgid "Commits changes to disk and quits barrel."
-msgstr "Aplica els canvis al disc i surt del barril."
+msgstr ""
 
 msgid "Continue?"
-msgstr "Voleu continuar?"
+msgstr ""
 
 msgid "Creates a new LVM logical volume."
-msgstr "Crea un volum lògic LVM nou."
+msgstr ""
 
 msgid "Creates a new LVM volume group."
-msgstr "Crea un grup de volums LVM nou."
+msgstr ""
 
 msgid "Creates a new RAID."
-msgstr "Crea una RAID nova."
+msgstr ""
 
 msgid "Creates a new encryption device."
-msgstr "Crea un dispositiu d'encriptació nou."
+msgstr ""
 
 msgid "Creates a new file system."
 msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1,119 +1,117 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR SUSE LLC
+# Chinese translations for barrel package
+# barrel 套件的正體中文翻譯.
+# Copyright (C) 2022 SUSE LLC
 # This file is distributed under the same license as the barrel package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Automatically generated, 2022.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: barrel VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-01-11 16:33+0100\n"
-"PO-Revision-Date: 2022-01-18 18:12+0000\n"
-"Last-Translator: David Medina <medipas@gmail.com>\n"
-"Language-Team: Catalan <https://l10n.opensuse.org/projects/barrel/master/ca/>"
-"\n"
-"Language: ca\n"
+"PO-Revision-Date: 2022-01-11 16:33+0100\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.9.1\n"
 
 msgid "Activating..."
-msgstr "Activant..."
+msgstr ""
 
 msgid "Adds devices to a pool."
-msgstr "Afegeix dispositius a una agrupació."
+msgstr ""
 
 msgid "Alias for 'create encryption --type luks1'"
-msgstr "Àlies per a \"create encryption --type luks1\""
+msgstr ""
 
 msgid "Alias for 'create encryption --type luks2'"
-msgstr "Àlies per a \"create encryption --type luks2\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type btrfs'"
-msgstr "Àlies per a \"create filesystem --type btrfs\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ext2'"
-msgstr "Àlies per a \"create filesystem --type ext2\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ext3'"
-msgstr "Àlies per a \"create filesystem --type ext3\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ext4'"
-msgstr "Àlies per a \"create filesystem --type ext4\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type f2fs'"
-msgstr "Àlies per a \"create filesystem --type f2fs\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type ntfs'"
-msgstr "Àlies per a \"create filesystem --type ntfs\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type swap'"
-msgstr "Àlies per a \"create filesystem --type swap\""
+msgstr ""
 
 msgid "Alias for 'create filesystem --type xfs'"
-msgstr "Àlies per a \"create filesystem --type xfs\""
+msgstr ""
 
 msgid "Alias for 'create partition-table --type gpt'"
-msgstr "Àlies per a \"create partition-table --type gpt\""
+msgstr ""
 
 msgid "Alias for 'create partition-table --type ms-dos'"
-msgstr "Àlies per a \"create partition-table --type ms-dos\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 0'"
-msgstr "Àlies per a \"create raid --level 0\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 1'"
-msgstr "Àlies per a \"create raid --level 1\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 10'"
-msgstr "Àlies per a \"create raid --level 10\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 4'"
-msgstr "Àlies per a \"create raid --level 4\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 5'"
-msgstr "Àlies per a \"create raid --level 5\""
+msgstr ""
 
 msgid "Alias for 'create raid --level 6'"
-msgstr "Àlies per a \"create raid --level 6\""
+msgstr ""
 
 msgid "Block Size"
-msgstr "Mida de bloc"
+msgstr ""
 
 msgid "Bus ID"
-msgstr "ID de BUS"
+msgstr ""
 
 msgid "Chunk Size"
-msgstr "Mida del tros"
+msgstr ""
 
 msgid "Clears the stack."
-msgstr "Neteja la pila."
+msgstr ""
 
 msgid "Commands:"
-msgstr "Ordres:"
+msgstr ""
 
 msgid "Commit changes?"
-msgstr "Voleu aplicar els canvis?"
+msgstr ""
 
 msgid "Commits changes to disk and quits barrel."
-msgstr "Aplica els canvis al disc i surt del barril."
+msgstr ""
 
 msgid "Continue?"
-msgstr "Voleu continuar?"
+msgstr ""
 
 msgid "Creates a new LVM logical volume."
-msgstr "Crea un volum lògic LVM nou."
+msgstr ""
 
 msgid "Creates a new LVM volume group."
-msgstr "Crea un grup de volums LVM nou."
+msgstr ""
 
 msgid "Creates a new RAID."
-msgstr "Crea una RAID nova."
+msgstr ""
 
 msgid "Creates a new encryption device."
-msgstr "Crea un dispositiu d'encriptació nou."
+msgstr ""
 
 msgid "Creates a new file system."
 msgstr ""


### PR DESCRIPTION
Weblate has a limitation: Components that has no po file will not appear in the component list. As we need to make it visible there, we need to initialize them.

Done automatically by:
`for L in pt_BR zh_CN zh_TW fr de it ja es ; do msginit --no-translator -l $L.UTF-8 -i *.pot -o $L.po ; done`
Revert existing files.
`sed -i 's/PACKAGE/barrel/' *.po`