### PR TITLE
Make auto completion context aware

### DIFF
--- a/barrel/Utils/CompletionHelper.cc
+++ b/barrel/Utils/CompletionHelper.cc
@@ -1,0 +1,456 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+#include <dirent.h>
+#include <sys/stat.h>
+#include <iomanip>
+#include "CompletionHelper.h"
+
+
+namespace barrel
+{
+
+    CompletionHelper::CompletionHelper():
+	storage(nullptr)
+    {
+    }
+
+
+    void
+    CompletionHelper::set_storage(const Storage* r_storage)
+    {
+	storage = r_storage;
+    }
+
+
+    void
+    CompletionHelper::CompletionResult::clear(const string text)
+    {
+	items.clear();
+    }
+
+
+    void
+    CompletionHelper::CompletionResult::push(Category category, const string& name, const string& desc, const string& display)
+    {
+	items.push_back({name, desc, category, display});
+    }
+
+
+    void
+    CompletionHelper::CompletionResult::push_command(const string& name, const string& desc)
+    {
+	push(Category::COMMAND, name, desc);
+    }
+
+
+    void
+    CompletionHelper::CompletionResult::push_argument(const string& name, const string& desc, const string& display)
+    {
+	push(Category::ARGUMENT, name, desc, display);
+    }
+
+
+    void
+    CompletionHelper::CompletionResult::push_pool(const string& name)
+    {
+	push(Category::POOL, name);
+    }
+
+
+    void
+    CompletionHelper::CompletionResult::push_device(const string& name)
+    {
+	push(Category::DEVICE, name);
+    }
+
+
+    string
+    CompletionHelper::escape(const string& original)
+    {
+	string escaped;
+
+	for (char c : original)
+	{
+	    if (c == ' ')
+		escaped += '\\';
+
+	    escaped += c;
+	}
+
+	return escaped;
+    }
+
+
+    string
+    CompletionHelper::unescape(const string& original)
+    {
+	string unescaped;
+
+	for (size_t i = 0; i < original.length(); ++i)
+	{
+	    if (original[i] == '\\' && i + 1 < original.length() && original[i + 1] == ' ')
+	    {
+		unescaped += ' ';
+		++i;
+	    }
+	    else
+		unescaped += original[i];
+	}
+
+	return unescaped;
+    }
+
+
+    string
+    CompletionHelper::removeAfterNthSlash(string str, int n)
+    {
+	size_t pos = 0;
+	int count = 0;
+
+	// Find the position of the n-th '/'
+	while (count < n && (pos = str.find('/', pos)) != string::npos)
+	{
+	    count++;
+	    if (count < n)
+		pos++;
+	}
+
+	if (count == n && pos != string::npos)
+	    str.erase(pos + 1);
+
+	return str;
+    }
+
+
+    bool
+    CompletionHelper::starts_with(const string &input, const string &prefix)
+    {
+	if (prefix.length() > input.length())
+	    return false;
+
+	return input.compare(0, prefix.length(), prefix) == 0;
+    }
+
+
+    const MainCmd*
+    CompletionHelper::find_main_cmd(const string &name)
+    {
+	for (const MainCmd& main_cmd : main_cmds)
+	{
+	    if (main_cmd.name == name)
+		return &main_cmd;
+	}
+	return nullptr;
+
+    }
+
+
+    tuple<const Parser*, size_t>
+    CompletionHelper::find_sub_cmd(const MainCmd* cmd, const vector<string> &tokens)
+    {
+	for (auto it = tokens.rbegin(); it != tokens.rend(); ++it)
+	{
+	    for (const Parser& sub_cmd : cmd->sub_cmds)
+	    {
+		if (sub_cmd.name == *it)
+		    return { &sub_cmd, tokens.size() - 1 - distance(tokens.rbegin(), it)};
+	    }
+	}
+	return { nullptr, string::npos };
+    }
+
+
+    const Option*
+    CompletionHelper::find_option(const Cmd* cmd, const string &text)
+    {
+	if (text.size() < 2 || text[0] != '-' || !cmd)
+	    return nullptr;
+
+	// long opt case, starting with --
+	if (text[1] == '-'){
+	    string opt_name = text.substr(2);
+	    for (const Option& opt : cmd->options().options)
+	    {
+		if (opt.name == opt_name)
+		    return &opt;
+	    }
+	}
+
+	// On short options, we only use the last letter
+	char short_opt = text.back();
+	for (const Option& opt : cmd->options().options)
+	{
+	    if (opt.c == short_opt)
+		return &opt;
+	}
+
+	return nullptr;
+    }
+
+
+    vector<string>
+    CompletionHelper::list_files_of_dir(const string &text)
+    {
+	vector<string> result;
+	string p = text.empty() ? "./" : text;
+
+	if (!storage)
+	    return result;
+
+	struct stat st;
+	if (stat(p.c_str(), &st) != 0 || !S_ISDIR(st.st_mode))
+	{
+	    size_t last_slash = p.find_last_of('/');
+	    if (last_slash != string::npos)
+		p = p.substr(0, last_slash + 1);
+	    else
+		p = "./";
+	}
+
+	DIR* dir = opendir(p.c_str());
+	if (!dir)
+	    return result;
+
+	string prefix = p;
+	if (prefix.back() != '/')
+	    prefix += "/";
+
+	struct dirent* entry;
+	while ((entry = readdir(dir)) != nullptr)
+	{
+	    string entry_name = entry->d_name;
+	    if (entry_name == "." || entry_name == "..")
+		continue;
+
+	    string full_path = prefix + entry_name;
+	    if (stat(full_path.c_str(), &st) == 0 && S_ISDIR(st.st_mode))
+		full_path += "/";
+
+	    result.push_back(full_path);
+	}
+	closedir(dir);
+
+	return result;
+    }
+
+
+    void
+    CompletionHelper::add_devices(CompletionResult &res, const string &text,
+	    const vector<string> all_devices)
+    {
+	const ptrdiff_t counted = count(text.begin(), text.end(), '/');
+	set<string> blk_matches;
+
+	for (const string& s : all_devices)
+	{
+	    if (!text.empty() && !starts_with(s, text))
+		continue;
+
+	    blk_matches.insert(removeAfterNthSlash(s, counted + 1));
+	}
+
+	// If only one match and it's a directory, include its children to avoid it being "taken"
+	// as unique immediately, allowing the user to see the next level on subsequent TAB.
+	if (blk_matches.size() == 1 && blk_matches.begin()->back() == '/')
+	{
+	    const string unique_match = *blk_matches.begin();
+	    for (const string& s : all_devices)
+	    {
+		if (s.compare(0, unique_match.length(), unique_match) == 0)
+		    blk_matches.insert(removeAfterNthSlash(s, counted + 2));
+	    }
+	}
+
+	for (const string& m : blk_matches)
+	    res.push_device(m);
+    }
+
+
+    const CompletionHelper::CompletionResult&
+    CompletionHelper::complete(const vector<string> &tokens, const string &text)
+    {
+	result.clear(text);
+
+	const MainCmd* main_cmd = nullptr;
+	const Option* option = nullptr;
+	const Cmd* cmd = nullptr;
+
+	if (tokens.empty() || !(main_cmd = find_main_cmd(tokens[0])))
+	{
+	    for (const MainCmd& cmd : main_cmds)
+	    {
+		if (starts_with(cmd.name, text))
+		    result.push_command(
+			    cmd.name,
+			    cmd.cmd ? cmd.cmd->help() : ""
+			    );
+	    }
+	    return result;
+	}
+
+	auto [sub_cmd, sub_cmd_idx] = find_sub_cmd(main_cmd, tokens);
+
+	cmd = sub_cmd ? sub_cmd->cmd.get() : main_cmd->cmd.get();
+
+	option = find_option(cmd, tokens.back());
+
+	if (option && option->has_arg != no_argument)
+	{
+	    switch (option->value_type)
+	    {
+		case ValueType::POOL:
+		    if (storage)
+			for (auto x : storage->get_pools())
+			    if (starts_with(x.first, text))
+				result.push_pool(x.first);
+		    break;
+
+		case ValueType::STRING_LIST:
+		    for (const auto& s : option->possible_values)
+			if (starts_with(s, text))
+			    result.push_argument(s, "");
+		    break;
+
+		case ValueType::PATH:
+		    add_devices(result, text, list_files_of_dir(text));
+		    break;
+
+		case ValueType::UNKNOWN:
+		default:
+		    string name = string("<") + (option->arg_name ? option->arg_name : "arg") + ">";
+		    result.push_argument(name, option->description ? option->description : "");
+		    // TODO try to avoid this extra empty value to get the
+		    // completions visible but not taken
+		    result.push_argument("", "");
+	    }
+
+	    return result;
+	}
+
+	for (const Parser& sub_cmd : main_cmd->sub_cmds){
+	    if (starts_with(sub_cmd.name, text))
+		result.push_command(
+			sub_cmd.name,
+			sub_cmd.cmd ? sub_cmd.cmd->help() : ""
+			);
+	}
+
+	if (cmd)
+	{
+	    for (const Option& option : cmd->options().options){
+		// skip deprecated options
+		if (!option.description)
+		    continue;
+
+		string name = string("--") + option.name;
+
+		// show options only once
+		if (find(tokens.begin() + (sub_cmd ? sub_cmd_idx: 1), tokens.end(), name) != tokens.end())
+		    continue;
+
+		string desc = option.description;
+		stringstream display;
+		if (option.c)
+		    display << "-" << option.c << " ";
+		else
+		    display << "   ";
+		display << "--" << option.name;
+		if (option.has_arg)
+		    display << " <" << option.arg_name << ">";
+
+		if (starts_with(name, text))
+		    result.push_argument(name, desc, display.str());
+	    }
+
+	    if (storage && cmd->options().take_blk_devices != TakeBlkDevices::NO)
+		add_devices(result, text.empty() ? "/dev/": text, possible_blk_devices(storage));
+	}
+
+	return result;
+    }
+
+
+    const CompletionHelper::CompletionResult&
+    CompletionHelper::get_result() {
+	return result;
+    }
+
+
+    ostream& operator<<(ostream& os, CompletionHelper::Category category) {
+	switch (category) {
+	    case CompletionHelper::Category::NONE:     return os << "";
+	    case CompletionHelper::Category::COMMAND:  return os << "COMMAND";
+	    case CompletionHelper::Category::ARGUMENT: return os << "ARGUMENT";
+	    case CompletionHelper::Category::POOL:     return os << "POOL";
+	    case CompletionHelper::Category::DEVICE:   return os << "DEVICE";
+	    default:                 return os << "Unknown";
+	}
+    }
+
+
+    void
+    CompletionHelper::display_comp_items(vector<reference_wrapper<const CompItem>> &items)
+    {
+	int desc_max_len = 20;
+	for (const CompItem& item: items)
+	    desc_max_len = max(desc_max_len, static_cast<int>(
+			item.display.empty() ? item.name.length() : item.display.length()));
+
+	for (const CompItem& item: items)
+	{
+	    cout << left << setw(desc_max_len + 2)
+		<< (item.display.empty() ? item.name : item.display)
+		<< item.desc << endl;
+	}
+    }
+
+
+    void
+    CompletionHelper::display_matches(char** matches, int num_matches, int max_length)
+    {
+	vector<Category> order = {
+	    Category::COMMAND,
+	    Category::ARGUMENT,
+	    Category::DEVICE,
+	    Category::POOL
+	};
+	map<Category, vector<reference_wrapper<const CompItem>>> grouped;
+
+	for (const auto& item : result.items)
+	    grouped[item.category].push_back(cref(item));
+
+	cout << endl;
+	for (auto cat : order)
+	{
+	    if (grouped.find(cat) == grouped.end())
+		continue;
+
+	    if (grouped.size() > 1)
+		cout << cat << "s:" << endl;
+
+	    display_comp_items(grouped.at(cat));
+
+	    if (grouped.size() > 1)
+		cout << endl;
+	}
+    }
+}

--- a/barrel/Utils/CompletionHelper.cc
+++ b/barrel/Utils/CompletionHelper.cc
@@ -1,0 +1,427 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+#include <filesystem>
+#include <iomanip>
+#include <boost/algorithm/string.hpp>
+#include "CompletionHelper.h"
+
+
+namespace barrel
+{
+
+    CompletionHelper::CompletionHelper():
+	storage(nullptr)
+    {
+    }
+
+
+    void
+    CompletionHelper::set_storage(const Storage* r_storage)
+    {
+	storage = r_storage;
+    }
+
+
+    void
+    CompletionHelper::CompletionResult::clear()
+    {
+	items.clear();
+    }
+
+
+    void
+    CompletionHelper::CompletionResult::push(Category category, const string& name, const string& desc, const string& display)
+    {
+	items.push_back({name, desc, category, display});
+    }
+
+
+    void
+    CompletionHelper::CompletionResult::push_command(const string& name, const string& desc)
+    {
+	push(Category::COMMAND, name, desc);
+    }
+
+
+    void
+    CompletionHelper::CompletionResult::push_argument(const string& name, const string& desc, const string& display)
+    {
+	push(Category::ARGUMENT, name, desc, display);
+    }
+
+
+    void
+    CompletionHelper::CompletionResult::push_pool(const string& name)
+    {
+	push(Category::POOL, name);
+    }
+
+
+    void
+    CompletionHelper::CompletionResult::push_device(const string& name)
+    {
+	push(Category::DEVICE, name);
+    }
+
+
+    string
+    CompletionHelper::escape(const string& original)
+    {
+	string escaped;
+
+	for (char c : original)
+	{
+	    if (c == ' ')
+		escaped += '\\';
+
+	    escaped += c;
+	}
+
+	return escaped;
+    }
+
+
+    string
+    CompletionHelper::unescape(const string& original)
+    {
+	string unescaped;
+
+	for (size_t i = 0; i < original.length(); ++i)
+	{
+	    if (original[i] == '\\' && i + 1 < original.length() && original[i + 1] == ' ')
+	    {
+		unescaped += ' ';
+		++i;
+	    }
+	    else
+		unescaped += original[i];
+	}
+
+	return unescaped;
+    }
+
+
+    string
+    CompletionHelper::removeAfterNthSlash(string str, int n) const
+    {
+	size_t pos = 0;
+	int count = 0;
+
+	// Find the position of the n-th '/'
+	while (count < n && (pos = str.find('/', pos)) != string::npos)
+	{
+	    count++;
+	    if (count < n)
+		pos++;
+	}
+
+	if (count == n && pos != string::npos)
+	    str.erase(pos + 1);
+
+	return str;
+    }
+
+
+    const MainCmd*
+    CompletionHelper::find_main_cmd(const string &name) const
+    {
+	for (const MainCmd& main_cmd : main_cmds)
+	{
+	    if (main_cmd.name == name)
+		return &main_cmd;
+	}
+	return nullptr;
+
+    }
+
+
+    pair<const Parser*, size_t>
+    CompletionHelper::find_sub_cmd(const MainCmd* cmd, const vector<string> &tokens) const
+    {
+	for (auto it = tokens.rbegin(); it != tokens.rend(); ++it)
+	{
+	    for (const Parser& sub_cmd : cmd->sub_cmds)
+	    {
+		if (sub_cmd.name == *it)
+		    return pair(&sub_cmd, tokens.size() - 1 - distance(tokens.rbegin(), it));
+	    }
+	}
+	return pair( nullptr, string::npos );
+    }
+
+
+    const Option*
+    CompletionHelper::find_option(const Cmd* cmd, const string &text) const
+    {
+	if (text.size() < 2 || text[0] != '-' || !cmd)
+	    return nullptr;
+
+	// long opt case, starting with --
+	if (text[1] == '-'){
+	    string opt_name = text.substr(2);
+	    for (const Option& opt : cmd->options().options)
+	    {
+		if (opt.name == opt_name)
+		    return &opt;
+	    }
+	}
+
+	// On short options, we only use the last letter
+	char short_opt = text.back();
+	for (const Option& opt : cmd->options().options)
+	{
+	    if (opt.c == short_opt)
+		return &opt;
+	}
+
+	return nullptr;
+    }
+
+
+    vector<string>
+    CompletionHelper::list_files_of_dir(const string &text) const
+    {
+	vector<string> result;
+	error_code ec;
+	filesystem::path p(text.empty() ? "./" : text);
+
+	if(!filesystem::is_directory(p, ec))
+	    p = p.parent_path();
+
+	try {
+	    for (const auto & entry : filesystem::directory_iterator(p))
+	    {
+		string name = entry.path().string();
+		if (entry.is_directory())
+		    name += "/";
+		result.push_back(name);
+	    }
+	} catch (...) {
+	    // ignore errors (e.g. permission denied)
+	}
+	return result;
+    }
+
+
+    void
+    CompletionHelper::add_devices(CompletionResult &res, const string &text,
+	    const vector<string> &all_devices) const
+    {
+	const ptrdiff_t counted = count(text.begin(), text.end(), '/');
+	set<string> blk_matches;
+
+	for (const string& s : all_devices)
+	{
+	    if (!text.empty() && !boost::starts_with(s, text))
+		continue;
+
+	    blk_matches.insert(removeAfterNthSlash(s, counted + 1));
+	}
+
+	// If only one match and it's a directory, include its children to avoid it being "taken"
+	// as unique immediately, allowing the user to see the next level on subsequent TAB.
+	if (blk_matches.size() == 1 && blk_matches.begin()->back() == '/')
+	{
+	    const string unique_match = *blk_matches.begin();
+	    for (const string& s : all_devices)
+	    {
+		if (s.compare(0, unique_match.length(), unique_match) == 0)
+		    blk_matches.insert(removeAfterNthSlash(s, counted + 2));
+	    }
+	}
+
+	for (const string& m : blk_matches)
+	    res.push_device(m);
+    }
+
+
+    const CompletionHelper::CompletionResult&
+    CompletionHelper::complete(const vector<string> &tokens, const string &text)
+    {
+	result.clear();
+
+	const MainCmd* main_cmd = nullptr;
+	const Option* option = nullptr;
+	const Cmd* cmd = nullptr;
+
+	if (tokens.empty() || !(main_cmd = find_main_cmd(tokens[0])))
+	{
+	    for (const MainCmd& cmd : main_cmds)
+	    {
+		if (boost::starts_with(cmd.name, text))
+		    result.push_command(
+			    cmd.name,
+			    cmd.cmd ? cmd.cmd->help() : ""
+			    );
+	    }
+	    return result;
+	}
+
+	auto [sub_cmd, sub_cmd_idx] = find_sub_cmd(main_cmd, tokens);
+
+	cmd = sub_cmd ? sub_cmd->cmd.get() : main_cmd->cmd.get();
+
+	option = find_option(cmd, tokens.back());
+
+	if (option && option->has_arg != no_argument)
+	{
+	    switch (option->value_type)
+	    {
+		case ValueType::POOL:
+		    if (storage)
+			for (auto x : storage->get_pools())
+			    if (boost::starts_with(x.first, text))
+				result.push_pool(x.first);
+		    break;
+
+		case ValueType::STRING_LIST:
+		    for (const auto& s : option->possible_values)
+			if (boost::starts_with(s, text))
+			    result.push_argument(s, "");
+		    break;
+
+		case ValueType::PATH:
+		    add_devices(result, text, list_files_of_dir(text));
+		    break;
+
+		case ValueType::UNKNOWN:
+		default:
+		    string name = string("<") + (option->arg_name ? option->arg_name : "arg") + ">";
+		    result.push_argument(name, option->description ? option->description : "");
+		    // TODO try to avoid this extra empty value to get the
+		    // completions visible but not taken
+		    result.push_argument("", "");
+	    }
+
+	    return result;
+	}
+
+	for (const Parser& sub_cmd : main_cmd->sub_cmds){
+	    if (boost::starts_with(sub_cmd.name, text))
+		result.push_command(
+			sub_cmd.name,
+			sub_cmd.cmd ? sub_cmd.cmd->help() : ""
+			);
+	}
+
+	if (cmd)
+	{
+	    for (const Option& option : cmd->options().options){
+		// skip deprecated options
+		if (!option.description)
+		    continue;
+
+		string name = string("--") + option.name;
+
+		// show options only once
+		if (find(tokens.begin() + (sub_cmd ? sub_cmd_idx: 1), tokens.end(), name) != tokens.end())
+		    continue;
+
+		string desc = option.description;
+		stringstream display;
+		if (option.c)
+		    display << "-" << option.c << " ";
+		else
+		    display << "   ";
+		display << "--" << option.name;
+		if (option.has_arg)
+		    display << " <" << option.arg_name << ">";
+
+		if (boost::starts_with(name, text))
+		    result.push_argument(name, desc, display.str());
+	    }
+
+	    if (storage && cmd->options().take_blk_devices != TakeBlkDevices::NO)
+		add_devices(result, text.empty() ? "/dev/": text, possible_blk_devices(storage));
+	}
+
+	return result;
+    }
+
+
+    const CompletionHelper::CompletionResult&
+    CompletionHelper::get_result() const
+    {
+	return result;
+    }
+
+
+    ostream& operator<<(ostream& os, CompletionHelper::Category category)
+    {
+	switch (category) {
+	    case CompletionHelper::Category::NONE:     return os << "";
+	    case CompletionHelper::Category::COMMAND:  return os << "COMMAND";
+	    case CompletionHelper::Category::ARGUMENT: return os << "ARGUMENT";
+	    case CompletionHelper::Category::POOL:     return os << "POOL";
+	    case CompletionHelper::Category::DEVICE:   return os << "DEVICE";
+	    default:                 return os << "Unknown";
+	}
+    }
+
+
+    void
+    CompletionHelper::display_comp_items(vector<reference_wrapper<const CompItem>> &items) const
+    {
+	int desc_max_len = 20;
+	for (const CompItem& item: items)
+	    desc_max_len = max(desc_max_len, static_cast<int>(
+			item.display.empty() ? item.name.length() : item.display.length()));
+
+	for (const CompItem& item: items)
+	{
+	    cout << left << setw(desc_max_len + 2)
+		<< (item.display.empty() ? item.name : item.display)
+		<< item.desc << endl;
+	}
+    }
+
+
+    void
+    CompletionHelper::display_matches(char** matches, int num_matches, int max_length) const
+    {
+	vector<Category> order = {
+	    Category::COMMAND,
+	    Category::ARGUMENT,
+	    Category::DEVICE,
+	    Category::POOL
+	};
+	map<Category, vector<reference_wrapper<const CompItem>>> grouped;
+
+	for (const auto& item : result.items)
+	    grouped[item.category].push_back(cref(item));
+
+	cout << endl;
+	for (auto cat : order)
+	{
+	    if (grouped.find(cat) == grouped.end())
+		continue;
+
+	    if (grouped.size() > 1)
+		cout << cat << "s:" << endl;
+
+	    display_comp_items(grouped.at(cat));
+
+	    if (grouped.size() > 1)
+		cout << endl;
+	}
+    }
+}

--- a/barrel/Utils/CompletionHelper.h
+++ b/barrel/Utils/CompletionHelper.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+
+#ifndef BARREL_COMPLETION_PROVIDER_H
+#define BARREL_COMPLETION_PROVIDER_H
+
+
+#include <string>
+#include <vector>
+#include <map>
+#include <ostream>
+#include <set>
+#include "../cmds.h"
+#include "Misc.h"
+
+
+namespace barrel
+{
+
+    class CompletionHelper
+    {
+    public:
+
+	static string escape(const string& original);
+	static string unescape(const string& original);
+
+	enum class Category { NONE, COMMAND, ARGUMENT, POOL, DEVICE };
+
+	struct CompItem
+	{
+	    string name;
+	    string desc;
+	    Category category;
+	    string display;         // Used only to display the autocompletions,
+				    // but name will be taken. Used for short arguments
+	};
+
+	class CompletionResult
+	{
+	public:
+	    void clear();
+	    void push_command(const string& name, const string& desc);
+	    void push_argument(const string& name, const string& desc, const string& display = "");
+	    void push_pool(const string& name);
+	    void push_device(const string& name);
+
+	    vector<CompItem> items;
+
+	private:
+	    void push(Category category, const string& name, const string& desc = "", const string& display = "");
+	};
+
+	CompletionHelper();
+
+	void set_storage(const Storage* storage);
+
+	const CompletionResult&
+	complete(const vector<string> &tokens, const string &text);
+
+	const CompletionResult&	get_result() const;
+
+	void display_matches(char** matches, int num_matches, int max_length) const;
+
+    private:
+
+	string removeAfterNthSlash(string str, int n) const;
+
+	const MainCmd* find_main_cmd(const string &name) const;
+
+	pair<const Parser*, size_t>
+	find_sub_cmd(const MainCmd* cmd, const vector<string> &items) const;
+
+	const Option* find_option(const Cmd* cmd, const string &text) const;
+
+	void display_comp_items(vector<std::reference_wrapper<const CompItem>> &items) const;
+
+	vector<string> list_files_of_dir(const string &text) const;
+
+	void add_devices(CompletionResult &res, const string &text, const vector<string> &all_devices) const;
+
+	const Storage* storage;
+
+	CompletionResult result;
+
+    };
+
+    std::ostream& operator<<(std::ostream& os, CompletionHelper::Category category);
+
+}
+
+
+#endif

--- a/barrel/Utils/CompletionHelper.h
+++ b/barrel/Utils/CompletionHelper.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+
+#ifndef BARREL_COMPLETION_PROVIDER_H
+#define BARREL_COMPLETION_PROVIDER_H
+
+
+#include <string>
+#include <vector>
+#include <map>
+#include <ostream>
+#include <set>
+#include "../cmds.h"
+#include "Misc.h"
+
+
+namespace barrel
+{
+
+    class CompletionHelper
+    {
+    public:
+
+	static string escape(const string& original);
+	static string unescape(const string& original);
+
+	enum class Category { NONE, COMMAND, ARGUMENT, POOL, DEVICE };
+
+	struct CompItem
+	{
+	    string name;
+	    string desc;
+	    Category category;
+	    string display;         // Used only to display the autocompletions,
+				    // but name will be taken. Used for short arguments
+	};
+
+	class CompletionResult
+	{
+	public:
+	    void clear(const string = "");
+	    void push_command(const string& name, const string& desc);
+	    void push_argument(const string& name, const string& desc, const string& display = "");
+	    void push_pool(const string& name);
+	    void push_device(const string& name);
+
+	    vector<CompItem> items;
+
+	private:
+	    void push(Category category, const string& name, const string& desc = "", const string& display = "");
+	};
+
+	CompletionHelper();
+
+	void set_storage(const Storage* storage);
+
+	const CompletionResult&
+	complete(const vector<string> &tokens, const string &text);
+
+	const CompletionResult&	get_result();
+
+	void display_matches(char** matches, int num_matches, int max_length);
+
+    private:
+
+	string removeAfterNthSlash(string str, int n);
+
+	const MainCmd* find_main_cmd(const string &name);
+
+	tuple<const Parser*, size_t>
+	find_sub_cmd(const MainCmd* cmd, const vector<string> &items);
+
+	const Option* find_option(const Cmd* cmd, const string &text);
+
+	void display_comp_items(vector<std::reference_wrapper<const CompItem>> &items);
+
+	vector<string> list_files_of_dir(const string &text);
+
+	void add_devices(CompletionResult &res, const string &text, const vector<string> all_files);
+
+	bool starts_with(const string &input, const string &test);
+
+	const Storage* storage;
+
+	CompletionResult result;
+
+    };
+
+    std::ostream& operator<<(std::ostream& os, CompletionHelper::Category category);
+
+}
+
+
+#endif

--- a/barrel/Utils/GetOpts.h
+++ b/barrel/Utils/GetOpts.h
@@ -48,6 +48,15 @@ namespace barrel
     };
 
 
+    enum class ValueType
+    {
+	UNKNOWN,
+	POOL,
+	PATH,
+	STRING_LIST
+    };
+
+
     struct Option
     {
 	const char* name;
@@ -55,6 +64,8 @@ namespace barrel
 	char c;
 	const char* description;	// may be null for deprecated options
 	const char* arg_name = nullptr;
+	ValueType value_type = ValueType::UNKNOWN;
+	vector<string> possible_values = {};
     };
 
 

--- a/barrel/Utils/Makefile.am
+++ b/barrel/Utils/Makefile.am
@@ -6,19 +6,20 @@ AM_CPPFLAGS = -I$(top_srcdir) $(XML2_CFLAGS)
 
 noinst_LTLIBRARIES = libutils.la
 
-libutils_la_SOURCES =			\
-	GetOpts.h	GetOpts.cc	\
-	Args.h				\
-	Table.h		Table.cc	\
-	Colors.h	Colors.cc	\
-	Text.h		Text.cc		\
-	JsonFile.h	JsonFile.cc	\
-	Readline.h	Readline.cc	\
-	Prompt.h	Prompt.cc	\
-	Misc.h		Misc.cc		\
-	Mockup.h	Mockup.cc	\
-	BarrelTmpl.h			\
+libutils_la_SOURCES =					\
+	GetOpts.h		GetOpts.cc		\
+	Args.h						\
+	Table.h			Table.cc		\
+	Colors.h		Colors.cc		\
+	Text.h			Text.cc			\
+	JsonFile.h		JsonFile.cc		\
+	Readline.h		Readline.cc		\
+	CompletionHelper.h 	CompletionHelper.cc 	\
+	Prompt.h		Prompt.cc		\
+	Misc.h			Misc.cc			\
+	Mockup.h		Mockup.cc		\
+	BarrelTmpl.h					\
 	BarrelDefines.h
 
-libutils_la_LIBADD =			\
+libutils_la_LIBADD =					\
 	-lstorage-ng -ljson-c

--- a/barrel/Utils/Misc.h
+++ b/barrel/Utils/Misc.h
@@ -50,6 +50,15 @@ namespace barrel
     string
     format_percentage(unsigned long long a, unsigned long long b, int precision = 2);
 
+    template<typename T>
+    inline vector<string>
+    map_keys(const map<string, T>& m)
+    {
+	vector<string> keys;
+	for (const auto& [key, value] : m)
+	    keys.push_back(key);
+	return keys;
+    }
 
     /**
      * Class to parse a number, e.g. "2". The special value "max" is also allowed. An

--- a/barrel/Utils/Readline.cc
+++ b/barrel/Utils/Readline.cc
@@ -31,17 +31,25 @@
 namespace barrel
 {
 
+    CompletionHelper Readline::completion;
+
     Readline::Readline(const Storage* storage, const Testsuite* testsuite)
 	: testsuite(testsuite)
     {
-	Readline::storage = storage;
+	completion.set_storage(storage);
 
 	// Note: readline allocates memory that partly cannot be freed.
 
 	rl_readline_name = "barrel";
 
 	rl_attempted_completion_function = my_completion;
-	rl_completer_quote_characters = "\"'";
+	rl_completion_display_matches_hook = my_display_matches;
+	rl_filename_quoting_function = my_quote_filename;
+	rl_basic_word_break_characters = " \t";
+	rl_completer_quote_characters = "'\"";
+	rl_filename_quote_characters = " ";
+	rl_sort_completion_matches = 0;
+	rl_char_is_quoted_p = my_char_is_quoted;
 
 	using_history();
 	stifle_history(1024);
@@ -83,80 +91,89 @@ namespace barrel
 	return line;
     }
 
-
-    string
-    Readline::escape(const string& original)
-    {
-	string escaped;
-
-	for (char c : original)
-	{
-	    if (c == ' ')
-		escaped += '\\';
-
-	    escaped += c;
-	}
-
-	return escaped;
-    }
-
-
     char*
     Readline::names_generator(const char* text, int state)
     {
-	static size_t list_index, len;
+	static size_t list_index;
 
 	if (state == 0)
-	{
 	    list_index = 0;
-	    len = strlen(text);
-	}
 
-	while (list_index < comp_names.size())
-	{
-	    const string& name = comp_names[list_index++];
-
-	    if (rl_completion_quote_character)
-	    {
-		if (strncmp(name.c_str(), text, len) == 0)
-		    return strdup(name.c_str());
-	    }
-	    else
-	    {
-		string tmp = escape(name);
-		if (strncmp(tmp.c_str(), text, len) == 0)
-		    return strdup(tmp.c_str());
-	    }
-	}
+	if (list_index < completion.get_result().items.size())
+	    return strdup(completion.get_result().items[list_index++].name.c_str());
 
 	return nullptr;
     }
 
-
     char**
     Readline::my_completion(const char* text, int start, int end)
     {
+	string_view line(rl_line_buffer, start);
+	string u_string = CompletionHelper::unescape(string(text));
+	vector<string> tokens;
+
+	// Disable default filename completion
 	rl_attempted_completion_over = 1;
 
-	// TODO make completion context aware
+	// Use filename completion mode to trigger quoting/dequoting
+	rl_filename_completion_desired = 1;
+	rl_filename_quoting_desired = 1;
 
-	comp_names = fixed_comp_names;
+	try {
 
-	// TODO normally tab completion only goes upto the path component
+	    if (!u_string.empty() && !line.empty()) {
+		char last = line.back();
+		if (last == '"' || last == '\'') {
+		    line.remove_suffix(1);
+		}
+	    }
+	    tokens = parse_line(line);
+	} catch (const std::runtime_error &e) {
+	    // silent ignore error, just no completion
+	    return nullptr;
+	}
 
-	for (auto x : possible_blk_devices(storage))
-	    comp_names.push_back(x);
+	// completion results are used in names_generator()
+	completion.complete(tokens, u_string);
 
-	for (auto x : storage->get_pools())
-	    comp_names.push_back(x.first);
+	return rl_completion_matches(u_string.c_str(), names_generator);
+    }
 
-	return rl_completion_matches(text, names_generator);
+    void
+    Readline::my_display_matches(char** matches, int num_matches, int max_length)
+    {
+	completion.display_matches(matches, num_matches, max_length);
+	rl_on_new_line();
     }
 
 
-    const Storage* Readline::storage;
+    int
+    Readline::my_char_is_quoted(char *text, int index)
+    {
+	return (index > 0 && text[index - 1] == '\\');
+    }
 
-    vector<string> Readline::fixed_comp_names;
-    vector<string> Readline::comp_names;
+
+    char*
+    Readline::my_quote_filename(char* s, int rtype, char* qcp)
+    {
+	char quote_char = rl_completer_quote_characters[0];
+
+	if (!strchr(s, ' '))
+	    return strdup(s);
+
+	if (qcp && qcp[0])
+	    quote_char = qcp[0];
+
+	size_t len = strlen(s);
+	char* quoted = (char*)malloc(len + 3);
+	quoted[0] = quote_char;
+	memcpy(quoted + 1, s, len);
+	if (rtype == SINGLE_MATCH) {
+	    quoted[len + 1] = quote_char;
+	    quoted[len + 2] = '\0';
+	}
+	return quoted;
+    }
 
 }

--- a/barrel/Utils/Readline.cc
+++ b/barrel/Utils/Readline.cc
@@ -31,17 +31,25 @@
 namespace barrel
 {
 
+    CompletionHelper Readline::completion;
+
     Readline::Readline(const Storage* storage, const Testsuite* testsuite)
 	: testsuite(testsuite)
     {
-	Readline::storage = storage;
+	completion.set_storage(storage);
 
 	// Note: readline allocates memory that partly cannot be freed.
 
 	rl_readline_name = "barrel";
 
 	rl_attempted_completion_function = my_completion;
-	rl_completer_quote_characters = "\"'";
+	rl_completion_display_matches_hook = my_display_matches;
+	rl_filename_quoting_function = my_quote_filename;
+	rl_basic_word_break_characters = " \t";
+	rl_completer_quote_characters = "'\"";
+	rl_filename_quote_characters = " ";
+	rl_sort_completion_matches = 0;
+	rl_char_is_quoted_p = my_char_is_quoted;
 
 	using_history();
 	stifle_history(1024);
@@ -83,80 +91,90 @@ namespace barrel
 	return line;
     }
 
-
-    string
-    Readline::escape(const string& original)
-    {
-	string escaped;
-
-	for (char c : original)
-	{
-	    if (c == ' ')
-		escaped += '\\';
-
-	    escaped += c;
-	}
-
-	return escaped;
-    }
-
-
     char*
     Readline::names_generator(const char* text, int state)
     {
-	static size_t list_index, len;
+	static size_t list_index;
 
 	if (state == 0)
-	{
 	    list_index = 0;
-	    len = strlen(text);
-	}
 
-	while (list_index < comp_names.size())
-	{
-	    const string& name = comp_names[list_index++];
-
-	    if (rl_completion_quote_character)
-	    {
-		if (strncmp(name.c_str(), text, len) == 0)
-		    return strdup(name.c_str());
-	    }
-	    else
-	    {
-		string tmp = escape(name);
-		if (strncmp(tmp.c_str(), text, len) == 0)
-		    return strdup(tmp.c_str());
-	    }
-	}
+	if (list_index < completion.get_result().items.size())
+	    return strdup(completion.get_result().items[list_index++].name.c_str());
 
 	return nullptr;
     }
 
-
     char**
     Readline::my_completion(const char* text, int start, int end)
     {
+	string_view line(rl_line_buffer, start);
+	string u_string = CompletionHelper::unescape(string(text));
+	vector<string> tokens;
+
+	// Disable default filename completion
 	rl_attempted_completion_over = 1;
 
-	// TODO make completion context aware
+	// Use filename completion mode to trigger quoting/dequoting
+	rl_filename_completion_desired = 1;
+	rl_filename_quoting_desired = 1;
 
-	comp_names = fixed_comp_names;
+	try {
 
-	// TODO normally tab completion only goes upto the path component
+	    if (!u_string.empty() && !line.empty()) {
+		char last = line.back();
+		if (last == '"' || last == '\'') {
+		    line.remove_suffix(1);
+		}
+	    }
+	    tokens = parse_line(line);
+	} catch (const std::runtime_error &e) {
+	    // silent ignore error, just no completion
+	    return nullptr;
+	}
 
-	for (auto x : possible_blk_devices(storage))
-	    comp_names.push_back(x);
+	const CompletionHelper::CompletionResult res = completion.complete(tokens, u_string);
 
-	for (auto x : storage->get_pools())
-	    comp_names.push_back(x.first);
+	return rl_completion_matches(u_string.c_str(), names_generator);
+    }
 
-	return rl_completion_matches(text, names_generator);
+    void
+    Readline::my_display_matches(char** matches, int num_matches, int max_length)
+    {
+	completion.display_matches(matches, num_matches, max_length);
+	rl_on_new_line();
     }
 
 
-    const Storage* Readline::storage;
+    int
+    Readline::my_char_is_quoted(char *text, int index)
+    {
+	return (index > 0 && text[index - 1] == '\\');
+    }
 
-    vector<string> Readline::fixed_comp_names;
-    vector<string> Readline::comp_names;
+
+    char*
+    Readline::my_quote_filename(char* s, int rtype, char* qcp)
+    {
+	char quote_char = rl_completer_quote_characters[0];
+
+	if (!strchr(s, ' '))
+	    return s;
+
+	if (qcp && qcp[0])
+	    quote_char = qcp[0];
+
+	size_t len = strlen(s);
+	char* quoted = (char*)malloc(len + 3);
+	quoted[0] = quote_char;
+	memcpy(quoted + 1, s, len);
+	if (quoted[len] == ' ') {
+	    quoted[len + 1] = '\0';
+	} else {
+	    quoted[len + 1] = quote_char;
+	    quoted[len + 2] = '\0';
+	}
+	return quoted;
+    }
 
 }

--- a/barrel/Utils/Readline.h
+++ b/barrel/Utils/Readline.h
@@ -25,6 +25,7 @@
 
 
 #include "Misc.h"
+#include "CompletionHelper.h"
 
 
 namespace barrel
@@ -41,11 +42,9 @@ namespace barrel
 
 	char* readline(const string& prompt);
 
-	static const Storage* storage;
-
-	static vector<string> fixed_comp_names;
-
     private:
+
+	static CompletionHelper completion;
 
 	const Testsuite* testsuite;
 
@@ -53,14 +52,15 @@ namespace barrel
 
 	vector<string>::const_iterator it;
 
-	static string escape(const string& original);
-
 	static char* names_generator(const char* text, int state);
 
 	static char** my_completion(const char* text, int start, int end);
 
-	static vector<string> comp_names;
+	static void my_display_matches(char** matches, int num_matches, int max_length);
 
+	static int my_char_is_quoted(char *text, int index);
+
+	static char* my_quote_filename(char* s, int rtype, char* qcp);
     };
 
 }

--- a/barrel/cmds.cc
+++ b/barrel/cmds.cc
@@ -155,28 +155,29 @@ namespace barrel
 	{ "pools", make_shared<CmdSavePools>() }
     };
 
+    const vector<Parser> empty_cmds;
 
     const vector<MainCmd> main_cmds = {
-	{ "[", make_shared<CmdOpenMark>(), {} },
-	{ "]", make_shared<CmdCloseMark>(), {} },
-	{ "clear", make_shared<CmdClear>(), {} },
-	{ "commit", make_shared<CmdCommit>(), {} },
+	{ "[", make_shared<CmdOpenMark>(), empty_cmds },
+	{ "]", make_shared<CmdCloseMark>(), empty_cmds },
+	{ "clear", make_shared<CmdClear>(), empty_cmds },
+	{ "commit", make_shared<CmdCommit>(), empty_cmds },
 	{ "create", nullptr, create_cmds },
-	{ "dup", make_shared<CmdDup>(), {} },
-	{ "exch", make_shared<CmdExch>(), {} },
+	{ "dup", make_shared<CmdDup>(), empty_cmds },
+	{ "exch", make_shared<CmdExch>(), empty_cmds },
 	{ "extend", nullptr, extend_cmds },
-	{ "help", make_shared<CmdHelp>(), {} },
+	{ "help", make_shared<CmdHelp>(), empty_cmds },
 	{ "load", nullptr, load_cmds },
-	{ "pop", make_shared<CmdPop>(), {} },
-	{ "quit", make_shared<CmdQuit>(), {} },
+	{ "pop", make_shared<CmdPop>(), empty_cmds },
+	{ "quit", make_shared<CmdQuit>(), empty_cmds },
 	{ "reduce", nullptr, reduce_cmds },
 	{ "remove", nullptr, remove_cmds },
 	{ "rename", nullptr, rename_cmds },
 	{ "resize", nullptr, resize_cmds },
 	{ "save", nullptr, save_cmds },
 	{ "show", nullptr, show_cmds },
-	{ "stack", make_shared<CmdStack>(), {} },
-	{ "undo", make_shared<CmdUndo>(), {} }
+	{ "stack", make_shared<CmdStack>(), empty_cmds },
+	{ "undo", make_shared<CmdUndo>(), empty_cmds }
     };
 
 }

--- a/barrel/create-encryption.cc
+++ b/barrel/create-encryption.cc
@@ -44,23 +44,6 @@ namespace barrel
     namespace
     {
 
-	const ExtOptions create_encryption_options({
-	    { "type", required_argument, 't', _("encryption type"), "type" },
-	    { "name", required_argument, 'n', _("set name of device"), "name" },
-	    { "label", required_argument, 0, _("set label of device"), "label" },
-	    { "activate-by", required_argument, 0, _("activate by"), "type" },
-	    { "activate-options", required_argument, 'o', _("activate options"), "options" },
-	    { "pool-name", required_argument, 0, _("pool name"), "name" },
-	    { "size", required_argument, 's', _("set size"), "size" },
-	    { "key-file", required_argument, 0, _("set a key file"), "key-file" },
-	    { "key-size", required_argument, 0, _("set key size"), "key-size" },
-	    { "cipher", required_argument, 0, _("set cipher"), "cipher" },
-	    { "pbkdf", required_argument, 0, _("set PBKDF"), "pbkdf" },
-	    { "no-etc-crypttab", no_argument, 0, _("do not add in /etc/crypttab") },
-	    { "no-crypttab", no_argument, 0, nullptr },	// deprecated
-	    { "force", no_argument, 0, _("force if block devices are in use") }
-	}, TakeBlkDevices::MAYBE);
-
 
 	const map<string, EncryptionType> str_to_encryption_type = {
 	    { "luks1", EncryptionType::LUKS1 },
@@ -79,6 +62,25 @@ namespace barrel
 	    { "partlabel", MountByType::PARTLABEL }
 #endif
 	};
+
+	const ExtOptions create_encryption_options({
+	    { "type", required_argument, 't', _("encryption type"), "type",
+		ValueType::STRING_LIST, map_keys(str_to_encryption_type) },
+	    { "name", required_argument, 'n', _("set name of device"), "name" },
+	    { "label", required_argument, 0, _("set label of device"), "label" },
+	    { "activate-by", required_argument, 0, _("activate by"), "type",
+		ValueType::STRING_LIST, map_keys(str_to_activate_by_type) },
+	    { "activate-options", required_argument, 'o', _("activate options"), "options" },
+	    { "pool-name", required_argument, 0, _("pool name"), "name", ValueType::POOL },
+	    { "size", required_argument, 's', _("set size"), "size" },
+	    { "key-file", required_argument, 0, _("set a key file"), "key-file", ValueType::PATH },
+	    { "key-size", required_argument, 0, _("set key size"), "key-size" },
+	    { "cipher", required_argument, 0, _("set cipher"), "cipher" },
+	    { "pbkdf", required_argument, 0, _("set PBKDF"), "pbkdf" },
+	    { "no-etc-crypttab", no_argument, 0, _("do not add in /etc/crypttab") },
+	    { "no-crypttab", no_argument, 0, nullptr },	// deprecated
+	    { "force", no_argument, 0, _("force if block devices are in use") }
+	}, TakeBlkDevices::MAYBE);
 
 
 	struct Options

--- a/barrel/create-filesystem.cc
+++ b/barrel/create-filesystem.cc
@@ -50,23 +50,6 @@ namespace barrel
     namespace
     {
 
-	const ExtOptions create_filesystem_options({
-	    { "type", required_argument, 't', _("set file system type"), "type" },
-	    { "label", required_argument, 'l', _("set file system label"), "label" },
-	    { "path", required_argument, 'p', _("mount path"), "path" },
-	    { "mount-by", required_argument, 0, _("mount by"), "type" },
-	    { "mount-options", required_argument, 'o', _("mount options"), "options" },
-	    { "mkfs-options", required_argument, 0, _("mkfs options"), "options" },
-	    { "tune-options", required_argument, 0, _("tune options"), "options" },
-	    { "pool-name", required_argument, 0, _("pool name"), "name" },
-	    { "size", required_argument, 's', _("set size"), "size" },
-	    { "devices", required_argument, 'd', _("set number of devices"), "number" },
-	    { "profiles", required_argument, 0, _("set profiles"), "profiles" },
-	    { "no-etc-fstab", no_argument, 0, _("do not add in /etc/fstab") },
-	    { "no-fstab", no_argument, 0, nullptr }, // deprecated
-	    { "force", no_argument, 0, _("force if block devices are in use") }
-	}, TakeBlkDevices::MAYBE);
-
 
 	const map<string, FsType> str_to_fs_type = {
 #if LIBSTORAGE_NG_VERSION_AT_LEAST(1, 100)
@@ -114,6 +97,27 @@ namespace barrel
 	    { "raid6", BtrfsRaidLevel::RAID6 },
 	    { "raid10", BtrfsRaidLevel::RAID10 }
 	};
+
+
+	const ExtOptions create_filesystem_options({
+	    { "type", required_argument, 't', _("set file system type"), "type",
+		ValueType::STRING_LIST, map_keys(str_to_fs_type) },
+	    { "label", required_argument, 'l', _("set file system label"), "label" },
+	    { "path", required_argument, 'p', _("mount path"), "path" },
+	    { "mount-by", required_argument, 0, _("mount by"), "type",
+		ValueType::STRING_LIST, map_keys(str_to_mount_by_type) },
+	    { "mount-options", required_argument, 'o', _("mount options"), "options" },
+	    { "mkfs-options", required_argument, 0, _("mkfs options"), "options" },
+	    { "tune-options", required_argument, 0, _("tune options"), "options" },
+	    { "pool-name", required_argument, 0, _("pool name"), "name", ValueType::POOL },
+	    { "size", required_argument, 's', _("set size"), "size" },
+	    { "devices", required_argument, 'd', _("set number of devices"), "number" },
+	    { "profiles", required_argument, 0, _("set profiles"), "profiles",
+		ValueType::STRING_LIST, map_keys(str_to_btrfs_raid_level) },
+	    { "no-etc-fstab", no_argument, 0, _("do not add in /etc/fstab") },
+	    { "no-fstab", no_argument, 0, nullptr }, // deprecated
+	    { "force", no_argument, 0, _("force if block devices are in use") }
+	}, TakeBlkDevices::MAYBE);
 
 
 	BtrfsRaidLevel

--- a/barrel/create-lvm-vg.cc
+++ b/barrel/create-lvm-vg.cc
@@ -44,7 +44,7 @@ namespace barrel
 
 	const ExtOptions create_lvm_vg_options({
 	    { "name", required_argument, 'n', _("set name of volume group"), "name" },
-	    { "pool-name", required_argument, 0, _("name of pool to use"), "name" },
+	    { "pool-name", required_argument, 0, _("name of pool to use"), "name", ValueType::POOL },
 	    { "size", required_argument, 's', _("set size of volume group"), "size" },
 	    { "devices", required_argument, 'd', _("set number of devices"), "number" },
 	    { "extent-size", required_argument, 0, _("set extent size"), "extent-size" },

--- a/barrel/create-partition-table.cc
+++ b/barrel/create-partition-table.cc
@@ -39,16 +39,18 @@ namespace barrel
     namespace
     {
 
-	const ExtOptions create_partition_table_options({
-	    { "type", required_argument, 't', _("partition table type"), "type" },
-	    { "force", no_argument, 0, _("force if block device is in use") }
-	}, TakeBlkDevices::MAYBE);
-
 
 	const map<string, PtType> str_to_pt_type = {
 	    { "gpt", PtType::GPT },
 	    { "ms-dos", PtType::MSDOS }
 	};
+
+
+	const ExtOptions create_partition_table_options({
+	    { "type", required_argument, 't', _("partition table type"), "type",
+		ValueType::STRING_LIST, map_keys(str_to_pt_type)},
+	    { "force", no_argument, 0, _("force if block device is in use") }
+	}, TakeBlkDevices::MAYBE);
 
 
 	struct Options

--- a/barrel/create-raid.cc
+++ b/barrel/create-raid.cc
@@ -46,18 +46,6 @@ namespace barrel
     namespace
     {
 
-	const ExtOptions create_raid_options({
-	    { "level", required_argument, 'l', _("set RAID level"), "level" },
-	    { "name", required_argument, 'n', _("set RAID name"), "name" },
-	    { "pool-name", required_argument, 0, _("name of pool to use"), "name" },
-	    { "size", required_argument, 's', _("set size of RAID"), "size" },
-	    { "metadata", required_argument, 'm', _("set RAID metadata version"), "metadata" },
-	    { "devices", required_argument, 'd', _("set number of devices"), "number" },
-	    { "chunk-size", required_argument, 0, _("set chunk size"), "chunk-size" },
-	    { "no-etc-mdadm", no_argument, 0, _("do not add in /etc/mdadm.conf") },
-	    { "force", no_argument, 0, _("force if block devices are in use") }
-	}, TakeBlkDevices::MAYBE);
-
 
 	const map<string, MdLevel> str_to_md_level = {
 #if LIBSTORAGE_NG_VERSION_AT_LEAST(1, 94)
@@ -72,6 +60,20 @@ namespace barrel
 	    { "6", MdLevel::RAID6 },
 	    { "10", MdLevel::RAID10 }
 	};
+
+
+	const ExtOptions create_raid_options({
+	    { "level", required_argument, 'l', _("set RAID level"), "level",
+		ValueType::STRING_LIST, map_keys(str_to_md_level) },
+	    { "name", required_argument, 'n', _("set RAID name"), "name" },
+	    { "pool-name", required_argument, 0, _("name of pool to use"), "name", ValueType::POOL },
+	    { "size", required_argument, 's', _("set size of RAID"), "size" },
+	    { "metadata", required_argument, 'm', _("set RAID metadata version"), "metadata" },
+	    { "devices", required_argument, 'd', _("set number of devices"), "number" },
+	    { "chunk-size", required_argument, 0, _("set chunk size"), "chunk-size" },
+	    { "no-etc-mdadm", no_argument, 0, _("do not add in /etc/mdadm.conf") },
+	    { "force", no_argument, 0, _("force if block devices are in use") }
+	}, TakeBlkDevices::MAYBE);
 
 
 	struct SmartRaidNumber

--- a/barrel/extend-pool.cc
+++ b/barrel/extend-pool.cc
@@ -39,7 +39,7 @@ namespace barrel
     {
 
 	const ExtOptions extend_pool_options({
-	    { "name", required_argument, 'n', _("name of pool"), "name" }
+	    { "name", required_argument, 'n', _("name of pool"), "name", ValueType::POOL }
 	}, TakeBlkDevices::YES);
 
 

--- a/barrel/handle.cc
+++ b/barrel/handle.cc
@@ -457,36 +457,6 @@ namespace barrel
     }
 
 
-    void
-    make_fixed_comp_names()
-    {
-	// this is only a workaround until completion is context aware
-
-	for (const MainCmd& main_cmd : main_cmds)
-	{
-	    Readline::fixed_comp_names.push_back(main_cmd.name);
-
-	    if (main_cmd.cmd)
-	    {
-		for (const Option& option : main_cmd.cmd->options().options)
-		    if (option.description)
-			Readline::fixed_comp_names.push_back("--"s + option.name);
-	    }
-	    else
-	    {
-		for (const Parser& sub_cmd : main_cmd.sub_cmds)
-		{
-		    Readline::fixed_comp_names.push_back(sub_cmd.name);
-
-		    for (const Option& option : sub_cmd.cmd->options().options)
-			if (option.description)
-			    Readline::fixed_comp_names.push_back("--"s + option.name);
-		}
-	    }
-	}
-    }
-
-
     bool
     interactive_ignore_line(const char* line)
     {
@@ -513,7 +483,6 @@ namespace barrel
 	startup(global_options, system_info, *storage);
 
 	Readline readline(storage.get(), testsuite);
-	make_fixed_comp_names();
 
 	State state(global_options);
 	state.storage = storage.get();

--- a/barrel/reduce-pool.cc
+++ b/barrel/reduce-pool.cc
@@ -39,7 +39,7 @@ namespace barrel
     {
 
 	const ExtOptions reduce_pool_options({
-	    { "name", required_argument, 'n', _("name of pool"), "name" }
+	    { "name", required_argument, 'n', _("name of pool"), "name", ValueType::POOL }
 	}, TakeBlkDevices::YES);
 
 

--- a/barrel/remove-pool.cc
+++ b/barrel/remove-pool.cc
@@ -37,7 +37,7 @@ namespace barrel
     {
 
 	const ExtOptions remove_pool_options({
-	    { "name", required_argument, 'n', _("name of pool"), "name" }
+	    { "name", required_argument, 'n', _("name of pool"), "name", ValueType::POOL }
 	});
 
 

--- a/barrel/rename-pool.cc
+++ b/barrel/rename-pool.cc
@@ -37,7 +37,7 @@ namespace barrel
     {
 
 	const ExtOptions rename_pool_options({
-	    { "old-name", required_argument, 'o', _("old name"), "name" },
+	    { "old-name", required_argument, 'o', _("old name"), "name", ValueType::POOL },
 	    { "new-name", required_argument, 'n', _("new name"), "name" }
 	});
 

--- a/barrel/show-filesystems.cc
+++ b/barrel/show-filesystems.cc
@@ -53,11 +53,6 @@ namespace barrel
     namespace
     {
 
-	const ExtOptions show_filesystems_options({
-	    { "probed", no_argument, 0, _("use probed instead of staging devicegraph") },
-	    { "probe-used-space", required_argument, 0, _("probe used space"), "mode" }
-	});
-
 
 	struct Options
 	{
@@ -75,6 +70,13 @@ namespace barrel
 	    { "active", Options::ProbeUsedSpace::ACTIVE },
 	    { "all", Options::ProbeUsedSpace::ALL }
 	};
+
+
+	const ExtOptions show_filesystems_options({
+	    { "probed", no_argument, 0, _("use probed instead of staging devicegraph") },
+	    { "probe-used-space", required_argument, 0, _("probe used space"), "mode",
+		ValueType::STRING_LIST, map_keys(str_to_probe_used_space) }
+	});
 
 
 	Options::Options(GetOpts& get_opts)

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -19,7 +19,7 @@ check_PROGRAMS =						\
 	remove2.test luks1.test gpt1.test misuse1.test		\
 	misuse2.test misuse3.test ext1.test btrfs1.test		\
 	stack1.test help1.test smart-size.test resize1.test	\
-	encryption1.test
+	encryption1.test completion.test
 
 AM_DEFAULT_SOURCE_EXT = .cc
 

--- a/testsuite/completion.cc
+++ b/testsuite/completion.cc
@@ -1,0 +1,129 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE barrel
+
+#include <boost/test/unit_test.hpp>
+
+#include "../barrel/Utils/CompletionHelper.h"
+#include "../barrel/Utils/Args.h"
+
+using namespace std;
+using namespace barrel;
+
+
+bool
+item_exists(const CompletionHelper::CompletionResult &res, const string &search)
+{
+    return find_if(res.items.begin(), res.items.end(),
+	    [&search](const auto& item) {
+		return item.name == search;
+	    }) != res.items.end();
+}
+
+
+BOOST_AUTO_TEST_CASE(test_escape_unescape)
+{
+    BOOST_CHECK_EQUAL(CompletionHelper::escape("foo bar"), "foo\\ bar");
+    BOOST_CHECK_EQUAL(CompletionHelper::unescape("foo\\ bar"), "foo bar");
+    BOOST_CHECK_EQUAL(CompletionHelper::escape("no_spaces"), "no_spaces");
+    BOOST_CHECK_EQUAL(CompletionHelper::unescape("no_spaces"), "no_spaces");
+}
+
+
+BOOST_AUTO_TEST_CASE(test_complete_commands)
+{
+    CompletionHelper helper;
+
+    // Empty input, should suggest all main commands
+    helper.complete({}, "");
+    BOOST_CHECK(item_exists(helper.get_result(), "create"));
+    BOOST_CHECK(item_exists(helper.get_result(), "show"));
+
+    // Partial input "sh"
+    helper.complete({}, "sh");
+    for (const auto& item : helper.get_result().items)
+        BOOST_CHECK(item.name.substr(0, 2) == "sh");
+
+    helper.complete({}, "XXXXXX");
+    BOOST_CHECK(helper.get_result().items.empty());
+}
+
+
+BOOST_AUTO_TEST_CASE(test_complete_subcommands)
+{
+    CompletionHelper helper;
+    const CompletionHelper::CompletionResult* res;
+
+    // "show " -> should suggest subcommands of show
+    res = &helper.complete({"show"}, "");
+    BOOST_CHECK(item_exists(*res, "disks"));
+    BOOST_CHECK(item_exists(*res, "pools"));
+
+    // "show di" -> should suggest disks
+    res = &helper.complete({"show"}, "di");
+    BOOST_REQUIRE(res != nullptr);
+    for (const auto& item : res->items)
+        BOOST_CHECK(item.name.substr(0, 2) == "di");
+
+    // Check if we get chained subcommand
+    res = &helper.complete({"show", "disk"}, "");
+    BOOST_CHECK(item_exists(*res, "pools"));
+}
+
+
+BOOST_AUTO_TEST_CASE(test_complete_options)
+{
+    CompletionHelper helper;
+    helper.complete({"show", "disks"}, "--");
+    BOOST_CHECK(item_exists(helper.get_result(), "--probed"));
+
+    // show options only once
+    helper.complete({"rename", "pool", "--old-name", "HDDs (512 B)"}, "");
+    BOOST_CHECK(!item_exists(helper.get_result(), "--old-name"));
+    BOOST_CHECK(item_exists(helper.get_result(), "--new-name"));
+
+    // check that show only once belongs only to the last subcommand
+    helper.complete({"rename", "pool", "--old-name", "HDDs (512 B)",
+	    "--new-name", "foo bar", "pool"}, "");
+    BOOST_CHECK(item_exists(helper.get_result(), "--old-name"));
+    BOOST_CHECK(item_exists(helper.get_result(), "--new-name"));
+}
+
+
+BOOST_AUTO_TEST_CASE(test_complete_option_values)
+{
+    CompletionHelper helper;
+
+    helper.complete({ "create", "filesystem", "--type"}, "");
+    BOOST_CHECK(item_exists(helper.get_result(), "btrfs"));
+    BOOST_CHECK(item_exists(helper.get_result(), "xfs"));
+    BOOST_CHECK(item_exists(helper.get_result(), "ext4"));
+
+    // unknown option
+    helper.complete({ "create", "filesystem"},  "--XXXX");
+    BOOST_CHECK(helper.get_result().items.empty());
+
+    // option without autocompletion
+    helper.complete({ "rename", "pool", "--new-name"}, "");
+    BOOST_CHECK(item_exists(helper.get_result(), "<name>"));
+}
+
+
+BOOST_AUTO_TEST_CASE(test_storage_dependent_completions)
+{
+    Testsuite testsuite;
+    testsuite.devicegraph_filename = "real1.xml";
+
+    Args args({ "--dry-run", "help" }); // Dummy call to initialize everything
+    handle(args.argc(), args.argv(), &testsuite);
+
+    CompletionHelper helper;
+    helper.set_storage(testsuite.storage.get());
+
+    // "show tree /dev/s" -> should suggest /dev/sda, /dev/sdb, /dev/sdc etc from real1.xml
+    helper.complete({"show", "tree"}, "/dev/s");
+    bool found_sda = false;
+    for (const auto& item : helper.get_result().items)
+        if (item.name == "/dev/sda") found_sda = true;
+
+    BOOST_CHECK(found_sda);
+}

--- a/testsuite/completion.cc
+++ b/testsuite/completion.cc
@@ -1,0 +1,123 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE barrel
+
+#include <boost/test/unit_test.hpp>
+
+#include "../barrel/Utils/CompletionHelper.h"
+#include "../barrel/Utils/Args.h"
+
+using namespace std;
+using namespace barrel;
+
+
+bool
+item_exists(const CompletionHelper::CompletionResult &res, const string &search)
+{
+    return find_if(res.items.begin(), res.items.end(),
+	    [&search](const auto& item) {
+		return item.name == search;
+	    }) != res.items.end();
+}
+
+
+BOOST_AUTO_TEST_CASE(test_escape_unescape)
+{
+    BOOST_CHECK_EQUAL(CompletionHelper::escape("foo bar"), "foo\\ bar");
+    BOOST_CHECK_EQUAL(CompletionHelper::unescape("foo\\ bar"), "foo bar");
+    BOOST_CHECK_EQUAL(CompletionHelper::escape("no_spaces"), "no_spaces");
+    BOOST_CHECK_EQUAL(CompletionHelper::unescape("no_spaces"), "no_spaces");
+}
+
+
+BOOST_AUTO_TEST_CASE(test_complete_commands)
+{
+    CompletionHelper helper;
+
+    // Empty input, should suggest all main commands
+    helper.complete({}, "");
+    BOOST_CHECK(item_exists(helper.get_result(), "create"));
+    BOOST_CHECK(item_exists(helper.get_result(), "show"));
+
+    // Partial input "re" -> reduce, remove, rename, resize
+    helper.complete({}, "re");
+    for (const auto& item : helper.get_result().items)
+        BOOST_CHECK(item.name.substr(0, 2) == "re");
+
+    helper.complete({}, "XXXXXX");
+    BOOST_CHECK(helper.get_result().items.empty());
+}
+
+
+BOOST_AUTO_TEST_CASE(test_complete_subcommands)
+{
+    CompletionHelper helper;
+
+    // "show " -> should suggest subcommands of show
+    helper.complete({"show"}, "");
+    BOOST_CHECK(item_exists(helper.get_result(), "disks"));
+    BOOST_CHECK(item_exists(helper.get_result(), "pools"));
+
+    // "show di" -> should suggest disks
+    helper.complete({"show"}, "di");
+    BOOST_CHECK(item_exists(helper.get_result(), "disks"));
+    BOOST_CHECK(!item_exists(helper.get_result(), "pools"));
+
+    // Check if we get chained subcommand
+    helper.complete({"show", "disk"}, "");
+    BOOST_CHECK(item_exists(helper.get_result(), "pools"));
+}
+
+
+BOOST_AUTO_TEST_CASE(test_complete_options)
+{
+    CompletionHelper helper;
+    helper.complete({"show", "disks"}, "--");
+    BOOST_CHECK(item_exists(helper.get_result(), "--probed"));
+
+    // show options only once
+    helper.complete({"rename", "pool", "--old-name", "HDDs (512 B)"}, "");
+    BOOST_CHECK(!item_exists(helper.get_result(), "--old-name"));
+    BOOST_CHECK(item_exists(helper.get_result(), "--new-name"));
+
+    // check that show only once belongs only to the last subcommand
+    helper.complete({"rename", "pool", "--old-name", "HDDs (512 B)",
+	    "--new-name", "foo bar", "pool"}, "");
+    BOOST_CHECK(item_exists(helper.get_result(), "--old-name"));
+    BOOST_CHECK(item_exists(helper.get_result(), "--new-name"));
+}
+
+
+BOOST_AUTO_TEST_CASE(test_complete_option_values)
+{
+    CompletionHelper helper;
+
+    helper.complete({ "create", "filesystem", "--type"}, "");
+    BOOST_CHECK(item_exists(helper.get_result(), "btrfs"));
+    BOOST_CHECK(item_exists(helper.get_result(), "xfs"));
+    BOOST_CHECK(item_exists(helper.get_result(), "ext4"));
+
+    // unknown option
+    helper.complete({ "create", "filesystem"},  "--XXXX");
+    BOOST_CHECK(helper.get_result().items.empty());
+
+    // option without autocompletion
+    helper.complete({ "rename", "pool", "--new-name"}, "");
+    BOOST_CHECK(item_exists(helper.get_result(), "<name>"));
+}
+
+
+BOOST_AUTO_TEST_CASE(test_storage_dependent_completions)
+{
+    Testsuite testsuite;
+    testsuite.devicegraph_filename = "real1.xml";
+
+    Args args({ "--dry-run", "help" }); // Dummy call to initialize everything
+    handle(args.argc(), args.argv(), &testsuite);
+
+    CompletionHelper helper;
+    helper.set_storage(testsuite.storage.get());
+
+    // "show tree /dev/s" -> should suggest /dev/sda, /dev/sdb, /dev/sdc etc from real1.xml
+    helper.complete({"show", "tree"}, "/dev/s");
+    BOOST_CHECK(item_exists(helper.get_result(), "/dev/sda"));
+}


### PR DESCRIPTION
This PR change the auto completion output to be context aware. 
It search for main- and sub- command. Depending on it the `devices`, `pools` and `arguments` are displayed.
If an `argument` should get a value, the `description` or `argument-name` is displayed.